### PR TITLE
Search paramters and GSON deserialization

### DIFF
--- a/src/main/java/com/arnaudpiroelle/marvel/api/MarvelApi.java
+++ b/src/main/java/com/arnaudpiroelle/marvel/api/MarvelApi.java
@@ -75,7 +75,7 @@ public class MarvelApi {
 
         private static final Gson gson = new GsonBuilder()
                 .setDateFormat("yyyy-MM-dd'T'HH:mm:ssZ")
-                .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+                //.setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
                 .create();
 
         private LogLevel logLevel= LogLevel.FULL;

--- a/src/main/java/com/arnaudpiroelle/marvel/api/params/name/comic/ListComicParamName.java
+++ b/src/main/java/com/arnaudpiroelle/marvel/api/params/name/comic/ListComicParamName.java
@@ -179,7 +179,19 @@ public enum ListComicParamName {
      * Parameter type: query
      * Data type: int
      */
-    OFFSET("offset");
+    OFFSET("offset"),
+
+
+    /**
+     * Description: the title of the comic desired
+     */
+    TITLE("title"),
+
+
+    /**
+     * Description: issue number desired
+     */
+    ISSUE_NUMBER("issueNumber");
 
     private String label;
 


### PR DESCRIPTION
Added search parameters for retrieving issues by title and issue number.

Removed setFieldNamingPolicy() from creation of GSON Builder. By leaving it set to the default,
tags with compound names, like attributionText and resourceURI are now processed.
